### PR TITLE
Switch to using example.com in help

### DIFF
--- a/src/main/java/com/ripariandata/timberwolf/App.java
+++ b/src/main/java/com/ripariandata/timberwolf/App.java
@@ -64,7 +64,7 @@ final class App implements PrivilegedAction<Integer>
 
     @Option(required = true, name = "--exchange-url",
             usage = "The URL of your Exchange Web Services endpoint.\nFor example: "
-                    + "https://example.contoso.com/ews/exchange.asmx")
+                    + "https://example.com/ews/exchange.asmx")
     private String exchangeUrl;
 
     @Option(name = "--hbase-quorum",


### PR DESCRIPTION
Instead of contoso.com (which redirects to microsoft.com/...) we should use example.com, which is reserved specifically for this purpose
