### PR TITLE
Less test info in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,27 +99,10 @@ Before submitting a pull request for approval, you should run the tests with `mv
 
 There are a number of integrated tests that you can also run if you'd like,
 but they are ignored by default. In order to run the integrated tests, you
-must have a working instance of HBase test against. And then you must
-create the file {project}/testing.properties that specifies the following
-properties:
-
-* *ZooKeeperQuorum*
-* *ZooKeeperClientPort*
-
-There are additional integrated tests which also require a working instance of
-Microsoft Exchange. Those tests will require these additional properties:
-
-* *ExchangeURI*
-* *LdapDomain*
-* *LdapConfigEntry*
-
-"testing.properties.example" is a sample file you can use to get you started.
-It also contains information about what each property means. Just rename the
-properties appropriately and rename the file to
-"testing.properties". All of these properties directly correspond to command
-line arguments that Timberwolf accepts (except for LdapConfigEntry).
-
-Timberwolf runs integrated tests by creating a temporary table in HBase to
-test against and then deleting it once the tests are complete. The tests will
-not remove any existing data from HBase, nor will they leave any testing data
-behind.
+must have a working instance of HBase test against.
+There is an additional integrated test which also requires a working instance
+of Microsoft Exchange.
+The integration tests require a set of properties that must be set in a
+`testing.properties` file, see `testing.properties.example` or [The online
+documentation](https://github.com/RiparianData/Timberwolf/wiki/Running-the-tests)
+for more information.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,6 @@ must have a working instance of HBase test against.
 There is an additional integrated test which also requires a working instance
 of Microsoft Exchange.
 The integration tests require a set of properties that must be set in a
-`testing.properties` file, see `testing.properties.example` or [The online
+`testing.properties` file, see `testing.properties.example` or [the online
 documentation](https://github.com/RiparianData/Timberwolf/wiki/Running-the-tests)
 for more information.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ additions conform to the coding convention.
 
 Before submitting a pull request for approval, you should run the tests with `mvn test`.
 
-There are a number of integrated tests that you can also run if you'd like,
+There are a number of integrated tests that you can also run, if you'd like,
 but they are ignored by default. In order to run the integrated tests, you
 must have a working instance of HBase to test against.
 There is an additional integrated test which also requires a working instance

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The final Timberwolf distribution artifacts will be in $project/target/.
 
 contact@ripariandata.com
 
-## Bug and Issue tracker.
+## Bug and Issue tracker
 
 All bugs and features are reported and tracked at:
 <https://ripariandata.atlassian.net>
@@ -37,11 +37,11 @@ means you will be required to supply a login configuration entry labeled
 
 We supply a sample_jaas.config file which contains a very basic Kerberos
 authentication configuration which may be suitable in your case. You can
-specify it either through the following Java commandline option:
+specify it either through the following Java command-line option:
 
-    -Djava.security.auth.login.config==sample_jaas.config
+    -Djava.security.auth.login.config=sample_jaas.config
 
-(note, this is a command line option to Java, not to the Timberwolf jar)
+(note, this is a command line option to Java, not to the Timberwolf JAR)
 
 ...or you can copy the Timberwolf entry in that file into ~/.java.login.config
 where Java will detect it automatically.
@@ -99,7 +99,7 @@ Before submitting a pull request for approval, you should run the tests with `mv
 
 There are a number of integrated tests that you can also run if you'd like,
 but they are ignored by default. In order to run the integrated tests, you
-must have a working instance of HBase test against.
+must have a working instance of HBase to test against.
 There is an additional integrated test which also requires a working instance
 of Microsoft Exchange.
 The integration tests require a set of properties that must be set in a

--- a/src/main/java/com/ripariandata/timberwolf/App.java
+++ b/src/main/java/com/ripariandata/timberwolf/App.java
@@ -64,7 +64,7 @@ final class App implements PrivilegedAction<Integer>
 
     @Option(required = true, name = "--exchange-url",
             usage = "The URL of your Exchange Web Services endpoint.\nFor example: "
-                    + "https://example.contoso.com/ews/exchange.asmx")
+                    + "https://example.com/ews/exchange.asmx")
     private String exchangeUrl;
 
     @Option(name = "--hbase-quorum",

--- a/testing.properties.example
+++ b/testing.properties.example
@@ -38,7 +38,7 @@
 ## These users will create a bunch of folders and send a bunch of
 ## emails amongst themselves and put them in said folders.
 ## When the test ends wipe out the contents of their mailboxes.
-## I repeat at the end of the test these users loose ALL their
+## I repeat at the end of the test these users lose ALL their
 ## emails. DO NOT use real users here.
 
 ## Instructions for how to set up the users is available online:

--- a/testing.properties.example
+++ b/testing.properties.example
@@ -3,6 +3,8 @@
 ## testing.properties in the current directory where you're
 ## running the tests, most likely the same directory as the
 ## pom.xml file.
+## More information on running the tests is available online:
+## https://github.com/RiparianData/Timberwolf/wiki/Running-the-tests
 ###############################################################
 
 ###############################################################
@@ -30,17 +32,17 @@
 ## Users necessary for exchange tests
 #######
 ## The following 5 users are required for the exchange integration
-## test. The authenticated user must be able to authenticate all
-## of these users in order to be able to run the test.
+## test. The authenticated user must be able to impersonate all
+## of these users, and no one else, in order to be able to run the
+## test.
 ## These users will create a bunch of folders and send a bunch of
 ## emails amongst themselves and put them in said folders.
 ## When the test ends wipe out the contents of their mailboxes.
 ## I repeat at the end of the test these users loose ALL their
 ## emails. DO NOT use real users here.
 
-## After the list of users is instructions on how to set up an
-## impersonation group so that the test will only get email
-## from a set of users
+## Instructions for how to set up the users is available online:
+## https://github.com/RiparianData/Timberwolf/wiki/Running-the-tests
 
 
 ## User #1 has a bunch of emails organized into many folders
@@ -55,42 +57,7 @@
 ## Sender sends all the emails and recieves a few more emails
 # ExchangeSender = testingUserForSending
 
-## Ignored is just another account that can receives emails
+## Ignored is just another account that can receive emails
 ## like sender this account is ignored when putting emails in hbase
 # ExchangeIgnoredUser = testingUserForRecieving
 
-
-##############################################################
-## Creating an impersonation group
-##############################################################
-# In order to create a security group set up for impersonation:
-# One will have to log into our Exchange test server.
-# Once all the mailboxes are created for the required users,
-# open up the Exchange Management Console and select Recipient
-# Configuration and then Distribution Group. Right click inside
-# the pane and select New Distribution Group. On the first page,
-# select "new group". On the second page, one must specify the
-# group type as security. Don't specify an organization unit,
-# and the names and aliases are arbitrary but make them all the
-# same. We will refer to this unique name as the SecurityGroupName.
-# On the last page simply press the "New" button and the group
-# should be created. It's not instantaneous, but should appear
-# within the list fairly quickly.
-#
-# The users will then have to be added to the security group.
-# Right-click on the security group name and select Properties.
-# Under the members tab is a list of all the current members and
-# an Add button. Clicking the add button will bring up a list of
-# members. Multi-select the users that need to be in the
-# impersonation group.
-#
-# Once the members are added, create a ManagementScope. Open the
-# Exchange Management Shell. Then run the following to create a
-# ManagementScope
-# with name "ScopeName" for the security group "SecurityGroupName"
-#   New-ManagementScope -Name:ScopeName -RecipientRestrictionFilter {MemberOfGroup -eq "cn=SecurityGroupName,cn=Users,DC=int,DC=tartarus,DC=com"}
-# Then create a ManagementRoleAssignment for jclouseau. To create a
-# ManagementRoleAssignment named "ManagementRoleAssignmentName" over
-# scope "ScopeName" for user: "testingSender" (A prime candidate is
-# the username for the sender):
-#   New-ManagementRoleAssignment -Name:ManagementRoleAssignmentName -Role:ApplicationImpersonation -User:testingSender -CustomRecipientWriteScope:ScopeName


### PR DESCRIPTION
There was a lot of repetition between the readme and our testing.properties.example and wiki, I replaced a bunch of that with links.
