### PR TITLE
Sync folder item iterator

### DIFF
--- a/src/main/java/com/ripariandata/timberwolf/exchange/FolderContext.java
+++ b/src/main/java/com/ripariandata/timberwolf/exchange/FolderContext.java
@@ -93,7 +93,8 @@ public class FolderContext
 
     /**
      * Returns the sync token that should be used when syncing this folder.
-     *
+     * This variable is cached, and only requires a call to the data store
+     * the first time it is accessed, if that.
      * @return The sync token, or the empty string if there is no token.
      */
     public String getSyncStateToken()
@@ -103,6 +104,8 @@ public class FolderContext
 
     /**
      * Sets the sync token returned from Exchange when syncing this folder.
+     * This should not be called until after all items are retrieved; this can
+     * be considered a permanent change; the old sync state is gone forever.
      * @param syncState The sync token from exchange. This should not be null.
      */
     public void setSyncStateToken(final String syncState)

--- a/src/main/java/com/ripariandata/timberwolf/exchange/SyncFolderItemIterator.java
+++ b/src/main/java/com/ripariandata/timberwolf/exchange/SyncFolderItemIterator.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright 2012 Riparian Data
+ * http://www.ripariandata.com
+ * contact@ripariandata.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ripariandata.timberwolf.exchange;
+
+import com.ripariandata.timberwolf.MailboxItem;
+import java.util.Iterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs a GetItemIterator over many ids, retrieved more efficiently with findItems.
+ * <p/>
+ * This class pages the calls to findItems.
+ */
+public class SyncFolderItemIterator extends BaseChainIterator<MailboxItem>
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SyncFolderItemIterator.class);
+    private ExchangeService service;
+    private Configuration config;
+    private FolderContext folder;
+    private boolean retrievedLastItem;
+
+    public SyncFolderItemIterator(final ExchangeService exchangeService,
+                                  final Configuration configuration,
+                                  final FolderContext folderContext)
+    {
+        service = exchangeService;
+        config = configuration;
+        folder = folderContext;
+    }
+
+    @Override
+    protected Iterator<MailboxItem> createIterator()
+    {
+        try
+        {
+            if (retrievedLastItem)
+            {
+                return null;
+            }
+            SyncFolderItemsHelper.SyncFolderItemsResult result =
+                    SyncFolderItemsHelper.syncFolderItems(service, config, folder);
+            LOG.debug("Got {} email ids, which was {}the last them.", result.getIds().size(),
+                      result.includesLastItem() ? "" : "not ");
+            retrievedLastItem = result.includesLastItem();
+            if (result.getIds().size() > 0)
+            {
+                return new GetItemIterator(service, result.getIds(), config, folder);
+            }
+            else
+            {
+                return null;
+            }
+        }
+        catch (ServiceCallException e)
+        {
+            throw ExchangeRuntimeException.log(LOG, new ExchangeRuntimeException("Failed to sync folder items.", e));
+        }
+        catch (HttpErrorException e)
+        {
+            throw ExchangeRuntimeException.log(LOG, new ExchangeRuntimeException("Failed to sync folder items.", e));
+        }
+    }
+}

--- a/src/main/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsHelper.java
+++ b/src/main/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsHelper.java
@@ -100,7 +100,7 @@ public final class SyncFolderItemsHelper
             throw new ServiceCallException(ServiceCallException.Reason.OTHER, "Null response from Exchange service.");
         }
         ArrayOfResponseMessagesType array = response.getResponseMessages();
-        SyncFolderItemsResult result = null;
+        SyncFolderItemsResult result = new SyncFolderItemsResult(folder.getSyncStateToken());
         for (SyncFolderItemsResponseMessageType message : array.getSyncFolderItemsResponseMessageArray())
         {
             ResponseCodeType.Enum errorCode = message.getResponseCode();
@@ -111,15 +111,11 @@ public final class SyncFolderItemsHelper
             }
             if (message.isSetSyncState())
             {
-                folder.setSyncStateToken(message.getSyncState());
+                result.setSyncState(message.getSyncState());
             }
             if (message.isSetIncludesLastItemInRange())
             {
-                result = new SyncFolderItemsResult(message.getIncludesLastItemInRange());
-            }
-            else
-            {
-                result = new SyncFolderItemsResult(false);
+                result.setIncludesLastItem(message.getIncludesLastItemInRange());
             }
 
             if (message.isSetChanges())
@@ -134,11 +130,13 @@ public final class SyncFolderItemsHelper
                 }
             }
         }
-        if (result == null)
+        // SyncFindItems always returns a new sync state, even if there's no changes
+        // so this implies that no sync state was in the response
+        if (result.getSyncState().equals(folder.getSyncStateToken()))
         {
             LOG.debug("Exchange responded without any messages");
             // return true, so that it won't just call it again
-            return new SyncFolderItemsResult(true);
+            result.setIncludesLastItem(true);
         }
         return result;
     }
@@ -147,23 +145,54 @@ public final class SyncFolderItemsHelper
     public static class SyncFolderItemsResult
     {
         private final Vector<String> ids;
-        private final boolean includesLastItem;
+        private boolean includesLastItem;
+        private String syncState;
 
-        public SyncFolderItemsResult(final boolean returnedAllItems)
+        private SyncFolderItemsResult(final String oldSyncState)
         {
             ids = new Vector<String>();
-            includesLastItem = returnedAllItems;
+            syncState = oldSyncState;
         }
 
+        /** The ids returned by the sync request. */
         public Vector<String> getIds()
         {
             return ids;
         }
 
+        /**
+         * The sync state returned by the request.
+         * If there was a problem, this will be the same sync state
+         * as the one passed in.
+         *
+         * @return The sync state returned by the request.
+         */
+        public String getSyncState()
+        {
+            return syncState;
+        }
+
+        /**
+         * Whether or not the sync response included
+         * the last item to be synced.
+         *
+         * @return true if all items have been returned.
+         */
         public boolean includesLastItem()
         {
             return includesLastItem;
         }
+
+        private void setIncludesLastItem(final boolean includesLastItem)
+        {
+            this.includesLastItem = includesLastItem;
+        }
+
+        private void setSyncState(final String syncState)
+        {
+            this.syncState = syncState;
+        }
+
     }
 
 }

--- a/src/main/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsHelper.java
+++ b/src/main/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsHelper.java
@@ -142,7 +142,7 @@ public final class SyncFolderItemsHelper
     }
 
     /** The result returned from syncing a folder's items. */
-    public static class SyncFolderItemsResult
+    public static final class SyncFolderItemsResult
     {
         private final Vector<String> ids;
         private boolean includesLastItem;
@@ -183,14 +183,14 @@ public final class SyncFolderItemsHelper
             return includesLastItem;
         }
 
-        private void setIncludesLastItem(final boolean includesLastItem)
+        private void setIncludesLastItem(final boolean includesLastItemFromResponse)
         {
-            this.includesLastItem = includesLastItem;
+            includesLastItem = includesLastItemFromResponse;
         }
 
-        private void setSyncState(final String syncState)
+        private void setSyncState(final String newSyncState)
         {
-            this.syncState = syncState;
+            syncState = newSyncState;
         }
 
     }

--- a/src/main/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsHelper.java
+++ b/src/main/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsHelper.java
@@ -101,8 +101,10 @@ public final class SyncFolderItemsHelper
         }
         ArrayOfResponseMessagesType array = response.getResponseMessages();
         SyncFolderItemsResult result = new SyncFolderItemsResult(folder.getSyncStateToken());
+        boolean hasMessages = false;
         for (SyncFolderItemsResponseMessageType message : array.getSyncFolderItemsResponseMessageArray())
         {
+            hasMessages = true;
             ResponseCodeType.Enum errorCode = message.getResponseCode();
             if (errorCode != null && errorCode != ResponseCodeType.NO_ERROR)
             {
@@ -130,12 +132,10 @@ public final class SyncFolderItemsHelper
                 }
             }
         }
-        // SyncFindItems always returns a new sync state, even if there's no changes
-        // so this implies that no sync state was in the response
-        if (result.getSyncState().equals(folder.getSyncStateToken()))
+        if (!hasMessages)
         {
             LOG.debug("Exchange responded without any messages");
-            // return true, so that it won't just call it again
+            // so that we don't keep calling over and over again
             result.setIncludesLastItem(true);
         }
         return result;

--- a/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeMailStoreTest.java
+++ b/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeMailStoreTest.java
@@ -247,12 +247,12 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         int index = 0;
         List<String> ids = generateIds(0, itemsInExchange, getDefaultFolderId());
         while (mailItor.hasNext())
-     {
-         MailboxItem item = mailItor.next();
-         assertEquals(ids.get(index), item.getHeader("Item ID"));
-         index++;
-     }
-     assertEquals(itemsInExchange, index);
+        {
+            MailboxItem item = mailItor.next();
+            assertEquals(ids.get(index), item.getHeader("Item ID"));
+            index++;
+        }
+        assertEquals(itemsInExchange, index);
     }
 
     @Test
@@ -324,8 +324,185 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
     }
 
     @Test
+    public void testSyncFolderItemsOneIdPageTwoItemPages()
+            throws IOException, ServiceCallException,
+                   HttpErrorException, XmlException
+    {
+        final int itemsInExchange = 10;
+        final int idPageSize = 11;
+        final int itemPageSize = 5;
+        final String newSyncState = "New Sync State";
+        Configuration config = new Configuration(idPageSize, itemPageSize);
+        MessageType[] messages = mockSyncFolderItems(0, idPageSize, itemsInExchange, newSyncState);
+        mockGetItem(messages, 0, itemPageSize, 0, itemsInExchange, getDefaultFolderId());
+        mockGetItem(messages, 0, itemPageSize, 1, itemsInExchange, getDefaultFolderId());
+
+        SyncFolderItemIterator mailIterator = new SyncFolderItemIterator(getService(), config, getDefaultFolder());
+
+        int index = 0;
+        List<String> ids = generateIds(0, itemsInExchange, getDefaultFolderId());
+        while (mailIterator.hasNext())
+        {
+            MailboxItem item = mailIterator.next();
+            assertEquals(ids.get(index), item.getHeader("Item ID"));
+            index++;
+        }
+        assertEquals(itemsInExchange, index);
+    }
+
+    @Test
+    public void testSyncFolderItemsOneIdPageFiveItemPages()
+            throws IOException, ServiceCallException,
+                   HttpErrorException, XmlException
+    {
+        final int itemsInExchange = 24;
+        final int idPageSize = 30;
+        final int itemPageSize = 5;
+        final String newSyncState = "New sync state";
+        Configuration config = new Configuration(idPageSize, itemPageSize);
+        defaultMockFindFolders();
+        MessageType[] findResults = mockSyncFolderItems(0, idPageSize, itemsInExchange, newSyncState);
+        final int pageIndexCount = 5;
+        for (int i = 0; i < pageIndexCount; i++)
+        {
+            mockGetItem(findResults, 0, itemPageSize, i, itemsInExchange, getDefaultFolderId());
+        }
+
+        SyncFolderItemIterator mailIterator = new SyncFolderItemIterator(getService(), config, getDefaultFolder());
+
+        int index = 0;
+        List<String> ids = generateIds(0, itemsInExchange, getDefaultFolderId());
+        while (mailIterator.hasNext())
+        {
+            MailboxItem item = mailIterator.next();
+            assertEquals(ids.get(index), item.getHeader("Item ID"));
+            index++;
+        }
+        assertEquals(itemsInExchange, index);
+    }
+
+    @Test
+    public void testSyncFolderItemsTwoIdPages10ItemPages()
+            throws IOException, ServiceCallException, HttpErrorException, XmlException
+    {
+        final int itemsInExchange = 50;
+        final int idPageSize = 30;
+        final int itemPageSize = 5;
+        Configuration config = new Configuration(idPageSize, itemPageSize);
+        defaultMockFindFolders();
+        // SyncFolderItem #1
+        final String secondSyncState = "The second sync state";
+        final String lastSyncState = "The last sync state";
+        MessageType[] findResults = mockSyncFolderItems(0, idPageSize, idPageSize, secondSyncState, false);
+        final int findItemCount = 6;
+        for (int i = 0; i < findItemCount; i++)
+        {
+            mockGetItem(findResults, 0, itemPageSize, i, itemsInExchange, getDefaultFolderId());
+        }
+
+        // FindItem #2
+        getDefaultFolder().setSyncStateToken(secondSyncState);
+        findResults = mockSyncFolderItems(idPageSize, idPageSize, itemsInExchange - idPageSize, lastSyncState, true);
+        final int mockFindItemCount2 = 4;
+        for (int i = 0; i < mockFindItemCount2; i++)
+        {
+            mockGetItem(findResults, idPageSize, itemPageSize, i, itemsInExchange, getDefaultFolderId());
+        }
+
+        // set the default folder back to a sync state of null
+        getDefaultFolder().setSyncStateToken(null);
+        SyncFolderItemIterator mailIterator = new SyncFolderItemIterator(getService(), config, getDefaultFolder());
+
+        int index = 0;
+        List<String> ids = generateIds(0, itemsInExchange, getDefaultFolderId());
+        while (mailIterator.hasNext())
+        {
+            MailboxItem item = mailIterator.next();
+            assertEquals(ids.get(index), item.getHeader("Item ID"));
+            index++;
+        }
+        assertEquals(itemsInExchange, index);
+    }
+
+    @Test
+    public void testSyncFolderItemsFiveIdPages20ItemPages()
+            throws IOException, ServiceCallException,
+                   HttpErrorException, XmlException
+    {
+        final int itemsInExchange = 100;
+        final int idPageSize = 20;
+        final int itemPageSize = 5;
+        Configuration config = new Configuration(idPageSize, itemPageSize);
+        defaultMockFindFolders();
+        final int findOffsetCount = 5;
+        final int getOffsetCount = 4;
+        for (int i = 0; i < findOffsetCount; i++)
+        {
+            String newSyncState = "SyncState#" + i;
+            boolean includesLastItem = i == findOffsetCount - 1;
+            MessageType[] findResults = mockSyncFolderItems(i * idPageSize, idPageSize, idPageSize, newSyncState,
+                                                            includesLastItem);
+            getDefaultFolder().setSyncStateToken(newSyncState);
+            for (int j = 0; j < getOffsetCount; j++)
+            {
+                mockGetItem(findResults, idPageSize * i, itemPageSize, j, itemsInExchange, getDefaultFolderId());
+            }
+        }
+
+        // reset sync state
+        getDefaultFolder().setSyncStateToken(null);
+        SyncFolderItemIterator mailIterator = new SyncFolderItemIterator(getService(), config, getDefaultFolder());
+
+        int index = 0;
+        List<String> ids = generateIds(0, itemsInExchange, getDefaultFolderId());
+        while (mailIterator.hasNext())
+        {
+            MailboxItem item = mailIterator.next();
+            assertEquals(ids.get(index), item.getHeader("Item ID"));
+            index++;
+        }
+        assertEquals(itemsInExchange, index);
+    }
+
+    @Test
+    public void testSyncFolderItemsItemPageLargerThanIdPage()
+            throws IOException, ServiceCallException,
+                   HttpErrorException, XmlException
+    {
+        final int itemsInExchange = 20;
+        final int idPageSize = 5;
+        final int itemPageSize = 10;
+        Configuration config = new Configuration(idPageSize, itemPageSize);
+        defaultMockFindFolders();
+        final int offsetCount = 4;
+        for (int i = 0; i < offsetCount; i++)
+        {
+            String newSyncState = "SyncState#" + i;
+            boolean includesLastItem = i == offsetCount - 1;
+            MessageType[] findResults = mockSyncFolderItems(i * idPageSize, idPageSize, idPageSize, newSyncState,
+                                                            includesLastItem);
+            getDefaultFolder().setSyncStateToken(newSyncState);
+            mockGetItem(findResults, idPageSize * i, idPageSize, 0, itemsInExchange, getDefaultFolderId());
+        }
+
+        // reset sync state
+        getDefaultFolder().setSyncStateToken(null);
+        SyncFolderItemIterator mailIterator = new SyncFolderItemIterator(getService(), config, getDefaultFolder());
+
+        int index = 0;
+        List<String> ids = generateIds(0, itemsInExchange, getDefaultFolderId());
+        while (mailIterator.hasNext())
+        {
+            MailboxItem item = mailIterator.next();
+            assertEquals(ids.get(index), item.getHeader("Item ID"));
+            index++;
+        }
+        assertEquals(itemsInExchange, index);
+    }
+
+    @Test
     public void testGetMailWithPagingAndFolders() throws ServiceCallException, HttpErrorException, XmlException,
-            IOException
+                                                         IOException
     {
         FindFolderResponseType folderResponse = mock(FindFolderResponseType.class);
         ArrayOfResponseMessagesType folderArr = mock(ArrayOfResponseMessagesType.class);
@@ -353,16 +530,17 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         when(folderThreeId.getId()).thenReturn("FOLDER-THREE-ID");
         when(folderThree.getFolderId()).thenReturn(folderThreeId);
 
-        when(folders.getFolderArray()).thenReturn(new FolderType[] {folderOne, folderTwo, folderThree});
+        when(folders.getFolderArray()).thenReturn(new FolderType[]{folderOne, folderTwo, folderThree});
         when(parent.getFolders()).thenReturn(folders);
         when(folderMsgs.getRootFolder()).thenReturn(parent);
         when(folderMsgs.isSetRootFolder()).thenReturn(true);
-        FindFolderResponseMessageType[] fFRMT = new FindFolderResponseMessageType[] {folderMsgs};
+        FindFolderResponseMessageType[] fFRMT = new FindFolderResponseMessageType[]{folderMsgs};
         when(folderArr.getFindFolderResponseMessageArray()).thenReturn(fFRMT);
         when(folderResponse.getResponseMessages()).thenReturn(folderArr);
 
         when(getService().findFolder(likeThis(FindFolderHelper.getFindFoldersRequest(DistinguishedFolderIdNameType
-                .MSGFOLDERROOT)), eq(getDefaultUser()))).thenReturn(folderResponse);
+                                                                                             .MSGFOLDERROOT)),
+                                     eq(getDefaultUser()))).thenReturn(folderResponse);
         final int offsetZero = 0;
         final int offsetFive = 5;
         final int offsetTen = 10;
@@ -372,30 +550,30 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         final int countFive = 5;
         final int countTen = 10;
         mockFindItem("FOLDER-ONE-ID", offsetZero, maxIdTen, countTwo);
-        mockGetItem(new MessageType[] {mockMessageItemId("FOLDER-ONE-ID:the #0 id"),
-                                        mockMessageItemId("FOLDER-ONE-ID:the #1 id")},
+        mockGetItem(new MessageType[]{mockMessageItemId("FOLDER-ONE-ID:the #0 id"),
+                mockMessageItemId("FOLDER-ONE-ID:the #1 id")},
                     generateIds(offsetZero, countTwo, "FOLDER-ONE-ID"));
         mockFindItem("FOLDER-TWO-ID", offsetZero, maxIdTen, countTen);
-        mockGetItem(new MessageType[] {mockMessageItemId("FOLDER-TWO-ID:the #0 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #1 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #2 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #3 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #4 id")},
+        mockGetItem(new MessageType[]{mockMessageItemId("FOLDER-TWO-ID:the #0 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #1 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #2 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #3 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #4 id")},
                     generateIds(offsetZero, countFive, "FOLDER-TWO-ID"));
-        mockGetItem(new MessageType[] {mockMessageItemId("FOLDER-TWO-ID:the #5 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #6 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #7 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #8 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #9 id"), },
+        mockGetItem(new MessageType[]{mockMessageItemId("FOLDER-TWO-ID:the #5 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #6 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #7 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #8 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #9 id"),},
                     generateIds(offsetFive, countFive, "FOLDER-TWO-ID"));
         mockFindItem("FOLDER-TWO-ID", offsetTen, maxIdTen, countThree);
-        mockGetItem(new MessageType[] {mockMessageItemId("FOLDER-TWO-ID:the #10 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #11 id"),
-                                       mockMessageItemId("FOLDER-TWO-ID:the #12 id"), },
+        mockGetItem(new MessageType[]{mockMessageItemId("FOLDER-TWO-ID:the #10 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #11 id"),
+                mockMessageItemId("FOLDER-TWO-ID:the #12 id"),},
                     generateIds(offsetTen, countThree, "FOLDER-TWO-ID"));
         mockFindItem("FOLDER-THREE-ID", offsetZero, maxIdTen, countTwo);
-        mockGetItem(new MessageType[] {mockMessageItemId("FOLDER-THREE-ID:the #0 id"),
-                                       mockMessageItemId("FOLDER-THREE-ID:the #1 id")},
+        mockGetItem(new MessageType[]{mockMessageItemId("FOLDER-THREE-ID:the #0 id"),
+                mockMessageItemId("FOLDER-THREE-ID:the #1 id")},
                     generateIds(offsetZero, countTwo, "FOLDER-THREE-ID"));
 
         final int findItemPageSize = 10;
@@ -404,7 +582,7 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         Iterator<MailboxItem> mail = store.getMail(defaultUsers, new NoopUserTimeUpdater()).iterator();
         final int folderIdTwoCount = 13;
         final int folderIdOtherCount = 2;
-        for (String folder : new String[] {"FOLDER-ONE-ID", "FOLDER-TWO-ID", "FOLDER-THREE-ID"})
+        for (String folder : new String[]{"FOLDER-ONE-ID", "FOLDER-TWO-ID", "FOLDER-THREE-ID"})
         {
             for (int i = 0; i < (folder == "FOLDER-TWO-ID" ? folderIdTwoCount : folderIdOtherCount); i++)
             {
@@ -431,17 +609,17 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         when(bobFolder.getFolderId()).thenReturn(bobId);
         when(bobId.getId()).thenReturn("BOB-FOLDER");
 
-        mockFindFolders(new FolderType[] {aliceFolder}, "alice");
-        mockFindFolders(new FolderType[] {bobFolder}, "bob");
+        mockFindFolders(new FolderType[]{aliceFolder}, "alice");
+        mockFindFolders(new FolderType[]{bobFolder}, "bob");
         final int maxIdCount = 10;
         final int folderCount = 2;
         mockFindItem("ALICE-FOLDER", 0, maxIdCount, folderCount, "alice");
-        mockGetItem(new MessageType[] {mockMessageItemId("ALICE-FOLDER:the #0 id"),
-                                        mockMessageItemId("ALICE-FOLDER:the #1 id")},
+        mockGetItem(new MessageType[]{mockMessageItemId("ALICE-FOLDER:the #0 id"),
+                mockMessageItemId("ALICE-FOLDER:the #1 id")},
                     generateIds(0, folderCount, "ALICE-FOLDER"), "alice");
         mockFindItem("BOB-FOLDER", 0, maxIdCount, folderCount, "bob");
-        mockGetItem(new MessageType[] {mockMessageItemId("BOB-FOLDER:the #0 id"),
-                                        mockMessageItemId("BOB-FOLDER:the #1 id")},
+        mockGetItem(new MessageType[]{mockMessageItemId("BOB-FOLDER:the #0 id"),
+                mockMessageItemId("BOB-FOLDER:the #1 id")},
                     generateIds(0, folderCount, "BOB-FOLDER"), "bob");
 
         ArrayList<String> users = new ArrayList<String>();
@@ -454,7 +632,7 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         Iterator<MailboxItem> mail = store.getMail(users, new NoopUserTimeUpdater()).iterator();
 
         final int count = 2;
-        for (String folder : new String[] {"BOB-FOLDER", "ALICE-FOLDER"})
+        for (String folder : new String[]{"BOB-FOLDER", "ALICE-FOLDER"})
         {
             for (int i = 0; i < count; i++)
             {
@@ -481,7 +659,7 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         final int newMessageCount = 2;
         final int newMessageTime = 3000;
 
-        mockFindFolders(new FolderType[] {aliceFolder}, "alice");
+        mockFindFolders(new FolderType[]{aliceFolder}, "alice");
         MessageType[] allMessages = mockFindItem("ALICE-FOLDER", 0, findItemPageSize, totalMessageCount, "alice");
         mockGetItem(allMessages, generateIds(0, totalMessageCount, "ALICE-FOLDER"), "alice");
 

--- a/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeMailStoreTest.java
+++ b/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeMailStoreTest.java
@@ -593,12 +593,12 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
                 mockMessageItemId("FOLDER-TWO-ID:the #6 id"),
                 mockMessageItemId("FOLDER-TWO-ID:the #7 id"),
                 mockMessageItemId("FOLDER-TWO-ID:the #8 id"),
-                mockMessageItemId("FOLDER-TWO-ID:the #9 id"),},
+                mockMessageItemId("FOLDER-TWO-ID:the #9 id")},
                     generateIds(offsetFive, countFive, "FOLDER-TWO-ID"));
         mockFindItem("FOLDER-TWO-ID", offsetTen, maxIdTen, countThree);
         mockGetItem(new MessageType[]{mockMessageItemId("FOLDER-TWO-ID:the #10 id"),
                 mockMessageItemId("FOLDER-TWO-ID:the #11 id"),
-                mockMessageItemId("FOLDER-TWO-ID:the #12 id"),},
+                mockMessageItemId("FOLDER-TWO-ID:the #12 id")},
                     generateIds(offsetTen, countThree, "FOLDER-TWO-ID"));
         mockFindItem("FOLDER-THREE-ID", offsetZero, maxIdTen, countTwo);
         mockGetItem(new MessageType[]{mockMessageItemId("FOLDER-THREE-ID:the #0 id"),

--- a/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeMailStoreTest.java
+++ b/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeMailStoreTest.java
@@ -360,12 +360,11 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         final int itemPageSize = 5;
         final String newSyncState = "New sync state";
         Configuration config = new Configuration(idPageSize, itemPageSize);
-        defaultMockFindFolders();
-        MessageType[] findResults = mockSyncFolderItems(0, idPageSize, itemsInExchange, newSyncState);
+        MessageType[] syncResults = mockSyncFolderItems(0, idPageSize, itemsInExchange, newSyncState);
         final int pageIndexCount = 5;
         for (int i = 0; i < pageIndexCount; i++)
         {
-            mockGetItem(findResults, 0, itemPageSize, i, itemsInExchange, getDefaultFolderId());
+            mockGetItem(syncResults, 0, itemPageSize, i, itemsInExchange, getDefaultFolderId());
         }
 
         SyncFolderItemIterator mailIterator = new SyncFolderItemIterator(getService(), config, getDefaultFolder());
@@ -389,24 +388,23 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         final int idPageSize = 30;
         final int itemPageSize = 5;
         Configuration config = new Configuration(idPageSize, itemPageSize);
-        defaultMockFindFolders();
         // SyncFolderItem #1
         final String secondSyncState = "The second sync state";
         final String lastSyncState = "The last sync state";
-        MessageType[] findResults = mockSyncFolderItems(0, idPageSize, idPageSize, secondSyncState, false);
-        final int findItemCount = 6;
-        for (int i = 0; i < findItemCount; i++)
+        MessageType[] syncResults = mockSyncFolderItems(0, idPageSize, idPageSize, secondSyncState, false);
+        final int syncItemCount = 6;
+        for (int i = 0; i < syncItemCount; i++)
         {
-            mockGetItem(findResults, 0, itemPageSize, i, itemsInExchange, getDefaultFolderId());
+            mockGetItem(syncResults, 0, itemPageSize, i, itemsInExchange, getDefaultFolderId());
         }
 
-        // FindItem #2
+        // SyncItem #2
         getDefaultFolder().setSyncStateToken(secondSyncState);
-        findResults = mockSyncFolderItems(idPageSize, idPageSize, itemsInExchange - idPageSize, lastSyncState, true);
-        final int mockFindItemCount2 = 4;
-        for (int i = 0; i < mockFindItemCount2; i++)
+        syncResults = mockSyncFolderItems(idPageSize, idPageSize, itemsInExchange - idPageSize, lastSyncState, true);
+        final int mockSyncItemCount2 = 4;
+        for (int i = 0; i < mockSyncItemCount2; i++)
         {
-            mockGetItem(findResults, idPageSize, itemPageSize, i, itemsInExchange, getDefaultFolderId());
+            mockGetItem(syncResults, idPageSize, itemPageSize, i, itemsInExchange, getDefaultFolderId());
         }
 
         // set the default folder back to a sync state of null
@@ -433,19 +431,18 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         final int idPageSize = 20;
         final int itemPageSize = 5;
         Configuration config = new Configuration(idPageSize, itemPageSize);
-        defaultMockFindFolders();
-        final int findOffsetCount = 5;
+        final int syncOffsetCount = 5;
         final int getOffsetCount = 4;
-        for (int i = 0; i < findOffsetCount; i++)
+        for (int i = 0; i < syncOffsetCount; i++)
         {
             String newSyncState = "SyncState#" + i;
-            boolean includesLastItem = i == findOffsetCount - 1;
-            MessageType[] findResults = mockSyncFolderItems(i * idPageSize, idPageSize, idPageSize, newSyncState,
+            boolean includesLastItem = i == syncOffsetCount - 1;
+            MessageType[] syncResults = mockSyncFolderItems(i * idPageSize, idPageSize, idPageSize, newSyncState,
                                                             includesLastItem);
             getDefaultFolder().setSyncStateToken(newSyncState);
             for (int j = 0; j < getOffsetCount; j++)
             {
-                mockGetItem(findResults, idPageSize * i, itemPageSize, j, itemsInExchange, getDefaultFolderId());
+                mockGetItem(syncResults, idPageSize * i, itemPageSize, j, itemsInExchange, getDefaultFolderId());
             }
         }
 
@@ -473,16 +470,15 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         final int idPageSize = 5;
         final int itemPageSize = 10;
         Configuration config = new Configuration(idPageSize, itemPageSize);
-        defaultMockFindFolders();
         final int offsetCount = 4;
         for (int i = 0; i < offsetCount; i++)
         {
             String newSyncState = "SyncState#" + i;
             boolean includesLastItem = i == offsetCount - 1;
-            MessageType[] findResults = mockSyncFolderItems(i * idPageSize, idPageSize, idPageSize, newSyncState,
+            MessageType[] syncResults = mockSyncFolderItems(i * idPageSize, idPageSize, idPageSize, newSyncState,
                                                             includesLastItem);
             getDefaultFolder().setSyncStateToken(newSyncState);
-            mockGetItem(findResults, idPageSize * i, idPageSize, 0, itemsInExchange, getDefaultFolderId());
+            mockGetItem(syncResults, idPageSize * i, idPageSize, 0, itemsInExchange, getDefaultFolderId());
         }
 
         // reset sync state

--- a/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeMailStoreTest.java
+++ b/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeMailStoreTest.java
@@ -445,7 +445,8 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         final int syncOffsetCount = 5;
         final int getOffsetCount = 4;
         Vector<String> syncStates = new Vector<String>();
-        syncStates.add("");
+        syncStates.add("Original Sync State");
+        getDefaultFolder().setSyncStateToken(syncStates.get(0));
         for (int i = 0; i < syncOffsetCount; i++)
         {
             String newSyncState = "SyncState#" + i;
@@ -461,7 +462,7 @@ public class ExchangeMailStoreTest extends ExchangeTestBase
         }
 
         // reset sync state
-        getDefaultFolder().setSyncStateToken(null);
+        getDefaultFolder().setSyncStateToken(syncStates.get(0));
         SyncFolderItemIterator mailIterator = new SyncFolderItemIterator(getService(), config, getDefaultFolder());
 
         int index = 0;

--- a/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeTestBase.java
+++ b/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeTestBase.java
@@ -201,7 +201,7 @@ public class ExchangeTestBase
     }
 
     protected MessageType[] mockSyncFolderItems(final int offset, final int maxIds, final int itemsInExchange,
-                                              final String newSyncState, final boolean includesLastItem)
+                                                final String newSyncState, final boolean includesLastItem)
             throws ServiceCallException, HttpErrorException
     {
         MessageType[] messages = new MessageType[itemsInExchange];

--- a/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeTestBase.java
+++ b/src/test/java/com/ripariandata/timberwolf/exchange/ExchangeTestBase.java
@@ -193,6 +193,29 @@ public class ExchangeTestBase
         mockSyncFolderItems(ids, getDefaultFolder(), getDefaultConfig().getFindItemPageSize(), newSyncState);
     }
 
+    protected MessageType[] mockSyncFolderItems(final int offset, final int maxIds, final int itemsInExchange,
+                                                final String newSyncState)
+            throws ServiceCallException, HttpErrorException
+    {
+        return mockSyncFolderItems(offset, maxIds, itemsInExchange, newSyncState, true);
+    }
+
+    protected MessageType[] mockSyncFolderItems(final int offset, final int maxIds, final int itemsInExchange,
+                                              final String newSyncState, final boolean includesLastItem)
+            throws ServiceCallException, HttpErrorException
+    {
+        MessageType[] messages = new MessageType[itemsInExchange];
+        List<String> ids = generateIds(offset, itemsInExchange, getDefaultFolderId());
+        for (int i = 0; i < itemsInExchange; i++)
+        {
+            messages[i] = mockMessageItemId(ids.get(i));
+        }
+        mockSyncFolderItems(
+                generateIds(offset, itemsInExchange, getDefaultFolderId()).toArray(new String[itemsInExchange]),
+                getDefaultFolder(), maxIds, newSyncState, includesLastItem);
+        return messages;
+    }
+
     protected void mockSyncFolderItems(final String[] ids, final FolderContext folder, final int maxIds,
                                        final String newSyncState)
             throws ServiceCallException, HttpErrorException

--- a/src/test/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsTest.java
+++ b/src/test/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsTest.java
@@ -137,8 +137,9 @@ public class SyncFolderItemsTest extends ExchangeTestBase
     public void testSyncFolderItems1() throws ServiceCallException, HttpErrorException
     {
         String[] ids = new String[]{"onlyId"};
+        final String oldSyncState = "oldSyncState";
         final String newSyncState = "MySweetNewSyncState";
-        getDefaultFolder().setSyncStateToken("oldSyncState");
+        getDefaultFolder().setSyncStateToken(oldSyncState);
         mockSyncFolderItems(ids, newSyncState);
         SyncFolderItemsResult result =
                 SyncFolderItemsHelper.syncFolderItems(getService(), getDefaultConfig(), getDefaultFolder());
@@ -154,8 +155,9 @@ public class SyncFolderItemsTest extends ExchangeTestBase
     {
         final int count = 100;
         List<String> ids = generateIds(0, count, getDefaultFolderId());
+        final String oldSyncState = "oldSyncState";
         final String newSyncState = "MySweetNewSyncState";
-        getDefaultFolder().setSyncStateToken("oldSyncState");
+        getDefaultFolder().setSyncStateToken(oldSyncState);
         mockSyncFolderItems(ids.toArray(new String[ids.size()]), newSyncState);
         SyncFolderItemsResult result =
                 SyncFolderItemsHelper.syncFolderItems(getService(), getDefaultConfig(), getDefaultFolder());
@@ -183,8 +185,9 @@ public class SyncFolderItemsTest extends ExchangeTestBase
     {
         final int count = 100;
         List<String> ids = generateIds(0, count, getDefaultFolderId());
+        final String oldSyncState = "oldSyncState";
         final String newSyncState = "MySweetNewSyncState";
-        getDefaultFolder().setSyncStateToken("oldSyncState");
+        getDefaultFolder().setSyncStateToken(oldSyncState);
         mockSyncFolderItems(ids.toArray(new String[ids.size()]), getDefaultFolder(),
                             getDefaultConfig().getFindItemPageSize(), newSyncState, false);
         SyncFolderItemsResult result =
@@ -256,8 +259,9 @@ public class SyncFolderItemsTest extends ExchangeTestBase
     public void testUnsetIncludesLastItemInRange() throws ServiceCallException, HttpErrorException
     {
         String[] ids = new String[]{"onlyId"};
+        final String oldSyncState = "oldSyncState";
         final String newSyncState = "MySweetNewSyncState";
-        getDefaultFolder().setSyncStateToken("oldSyncState");
+        getDefaultFolder().setSyncStateToken(oldSyncState);
         SyncFolderItemsType syncItems = SyncFolderItemsHelper.getSyncFolderItemsRequest(getDefaultConfig(),
                                                                                         getDefaultFolder());
 
@@ -365,8 +369,9 @@ public class SyncFolderItemsTest extends ExchangeTestBase
     {
         final int count = 3;
         List<String> ids = generateIds(0, count, getDefaultFolderId());
+        final String oldSyncState = "oldSyncState";
         final String newSyncState = "MySweetNewSyncState";
-        getDefaultFolder().setSyncStateToken("oldSyncState");
+        getDefaultFolder().setSyncStateToken(oldSyncState);
         final SyncFolderItemsCreateOrUpdateType[] creates = new SyncFolderItemsCreateOrUpdateType[3];
         creates[0] = mockCreateItem(ids.get(0));
         creates[1] = mock(SyncFolderItemsCreateOrUpdateType.class);
@@ -386,8 +391,9 @@ public class SyncFolderItemsTest extends ExchangeTestBase
     {
         final int count = 3;
         List<String> ids = generateIds(0, count, getDefaultFolderId());
+        final String oldSyncState = "oldSyncState";
         final String newSyncState = "MySweetNewSyncState";
-        getDefaultFolder().setSyncStateToken("oldSyncState");
+        getDefaultFolder().setSyncStateToken(oldSyncState);
         final SyncFolderItemsCreateOrUpdateType[] creates = new SyncFolderItemsCreateOrUpdateType[3];
         creates[0] = mockCreateItem(ids.get(0));
         creates[1] = mock(SyncFolderItemsCreateOrUpdateType.class);

--- a/src/test/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsTest.java
+++ b/src/test/java/com/ripariandata/timberwolf/exchange/SyncFolderItemsTest.java
@@ -130,7 +130,8 @@ public class SyncFolderItemsTest extends ExchangeTestBase
                 .syncFolderItems(getService(), getDefaultConfig(), getDefaultFolder());
         assertEquals(0, result.getIds().size());
         assertTrue(result.includesLastItem());
-        assertEquals(myNewSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals("", getDefaultFolder().getSyncStateToken());
+        assertEquals(myNewSyncState, result.getSyncState());
     }
 
     @Test
@@ -147,7 +148,8 @@ public class SyncFolderItemsTest extends ExchangeTestBase
         expected.add("onlyId");
         assertEquals(expected, result.getIds());
         assertTrue(result.includesLastItem());
-        assertEquals(newSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(oldSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(newSyncState, result.getSyncState());
     }
 
     @Test
@@ -163,7 +165,8 @@ public class SyncFolderItemsTest extends ExchangeTestBase
                 SyncFolderItemsHelper.syncFolderItems(getService(), getDefaultConfig(), getDefaultFolder());
         assertEquals(ids, result.getIds());
         assertTrue(result.includesLastItem());
-        assertEquals(newSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(oldSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(newSyncState, result.getSyncState());
     }
 
     @Test
@@ -177,7 +180,8 @@ public class SyncFolderItemsTest extends ExchangeTestBase
                 .syncFolderItems(getService(), getDefaultConfig(), getDefaultFolder());
         assertEquals(0, result.getIds().size());
         assertFalse(result.includesLastItem());
-        assertEquals(myNewSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals("", getDefaultFolder().getSyncStateToken());
+        assertEquals(myNewSyncState, result.getSyncState());
     }
 
     @Test
@@ -194,7 +198,8 @@ public class SyncFolderItemsTest extends ExchangeTestBase
                 SyncFolderItemsHelper.syncFolderItems(getService(), getDefaultConfig(), getDefaultFolder());
         assertEquals(ids, result.getIds());
         assertFalse(result.includesLastItem());
-        assertEquals(newSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(oldSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(newSyncState, result.getSyncState());
     }
 
     @Test
@@ -225,8 +230,7 @@ public class SyncFolderItemsTest extends ExchangeTestBase
     public void testErrorResponseCode() throws ServiceCallException, HttpErrorException
     {
         final String oldState = "old sync state";
-        getDefaultFolder().setSyncStateToken("old sync state");
-
+        getDefaultFolder().setSyncStateToken(oldState);
         SyncFolderItemsType syncItems = SyncFolderItemsHelper.getSyncFolderItemsRequest(getDefaultConfig(),
                                                                                         getDefaultFolder());
 
@@ -290,8 +294,8 @@ public class SyncFolderItemsTest extends ExchangeTestBase
         expected.add("onlyId");
         assertEquals(expected, result.getIds());
         assertFalse(result.includesLastItem());
-        assertEquals(newSyncState, getDefaultFolder().getSyncStateToken());
-
+        assertEquals(oldSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(newSyncState, result.getSyncState());
     }
 
     @Test
@@ -329,6 +333,7 @@ public class SyncFolderItemsTest extends ExchangeTestBase
         assertEquals(expected, result.getIds());
         assertFalse(result.includesLastItem());
         assertEquals(oldSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(oldSyncState, result.getSyncState());
     }
 
     @Test
@@ -361,7 +366,8 @@ public class SyncFolderItemsTest extends ExchangeTestBase
                 .syncFolderItems(getService(), getDefaultConfig(), getDefaultFolder());
         assertEquals(0, result.getIds().size());
         assertTrue(result.includesLastItem());
-        assertEquals(myNewSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals("", getDefaultFolder().getSyncStateToken());
+        assertEquals(myNewSyncState, result.getSyncState());
     }
 
     @Test
@@ -383,7 +389,8 @@ public class SyncFolderItemsTest extends ExchangeTestBase
         ids.remove(1);
         assertEquals(ids, result.getIds());
         assertTrue(result.includesLastItem());
-        assertEquals(newSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(oldSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(newSyncState, result.getSyncState());
     }
 
     @Test
@@ -408,7 +415,8 @@ public class SyncFolderItemsTest extends ExchangeTestBase
         ids.remove(1);
         assertEquals(ids, result.getIds());
         assertTrue(result.includesLastItem());
-        assertEquals(newSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(oldSyncState, getDefaultFolder().getSyncStateToken());
+        assertEquals(newSyncState, result.getSyncState());
     }
 
 }


### PR DESCRIPTION
This calls sync folder items multiple times, until it gets all ids for the given folder.
