### PR TITLE
Explicitly flushing every 10K puts.

### DIFF
--- a/src/main/java/com/ripariandata/timberwolf/hbase/HBaseManager.java
+++ b/src/main/java/com/ripariandata/timberwolf/hbase/HBaseManager.java
@@ -78,6 +78,7 @@ public class HBaseManager
     public HBaseManager(final Configuration hbaseConfiguration)
     {
         configuration = hbaseConfiguration;
+        configuration.setLong("hbase.client.write.buffer", HBaseMailWriter.BUFFER_SIZE);
 
         try
         {


### PR DESCRIPTION
We used to buffer pretty much everything on the client, which had
sub-par performance implications.
